### PR TITLE
Ipv6 disable update via 3.1.1 logic improvement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## CIS 1.0.1
 
+- 3.1.1
+  - Added option to audit disable IPv6 via sysctl (original method) or via the kernel
 - updated version
 - 1.4.2 removed efi steps
 - 2.1.4 udpated for kea services

--- a/section_3/cis_3.1/cis_3.1.1.yml
+++ b/section_3/cis_3.1/cis_3.1.1.yml
@@ -5,7 +5,7 @@
 command:
   {{ if not .Vars.rhel10cis_ipv6_required }}
   ipv6_disabled:
-    title: 3.1.1 | Ensure IPv6 status is identified
+    title: 3.1.1 | Ensure IPv6 status is identified | IPv6 disabled
     exec: |
       if [ `grep 1 /proc/sys/net/ipv6/conf/all/disable_ipv6` ] || [ `grep 1 /proc/sys/net/ipv6/conf/default/disable_ipv6` ] || [ `cat /sys/module/ipv6/parameters/disable` == 1 ]; \
       then \
@@ -20,12 +20,16 @@ command:
       workstation: 1
       CIS_ID:
       - 3.1.1
+      CISv8: 4.8
+      CISv8_IG1: false
+      CISv8_IG2: true
+      CISv8_IG3: true
       NIST800-53R5:
       - CM-7
   {{ end }}
   {{ if .Vars.rhel10cis_ipv6_required }}
   ipv6_required:
-    title: 3.1.1 | Ensure IPv6 status is identified
+    title: 3.1.1 | Ensure IPv6 status is identified | IPv6 enabled
     exec: |
       if [ `grep 0 /proc/sys/net/ipv6/conf/all/disable_ipv6` ] || [ `grep 0 /proc/sys/net/ipv6/conf/default/disable_ipv6` ] || [ `cat /sys/module/ipv6/parameters/disable` == 0 ]; \
       then \
@@ -40,8 +44,50 @@ command:
       workstation: 1
       CIS_ID:
       - 3.1.1
+      CISv8: 4.8
+      CISv8_IG1: false
+      CISv8_IG2: true
+      CISv8_IG3: true
       NIST800-53R5:
       - CM-7
     {{ end }}
+  {{ if eq .Vars.rhel10cis_ipv6_disable_method "sysctl" }}
+  ipv6_disabled_sysctl:
+    title: 3.1.1 | Ensure IPv6 status is identified | IPv6 disabled via sysctl
+    exec: sysctl -a 2>/dev/null | grep -E 'net.ipv6.conf.(all|default).disable_ipv6 = 1'
+    exit-status: 0
+    stdout:
+    - 'net.ipv6.conf.all.disable_ipv6 = 1'
+    - 'net.ipv6.conf.default.disable_ipv6 = 1'
+    meta:
+      server: 1
+      workstation: 1
+      CIS_ID:
+      - 3.1.1
+      CISv8: 4.8
+      CISv8_IG1: false
+      CISv8_IG2: true
+      CISv8_IG3: true
+      NIST800-53R5:
+      - CM-7
+  {{ end }}
+  {{ if eq .Vars.rhel10cis_ipv6_disable_method "kernel" }}
+kernel-param:
+  ipv6.disable:
+    title: 3.1.1 | Ensure IPv6 status is identified | IPv6 disabled via kernel parameter
+    value: '1'
+    name: ipv6.disable
+    meta:
+      server: 1
+      workstation: 1
+      CIS_ID:
+      - 3.1.1
+      CISv8: 4.8
+      CISv8_IG1: false
+      CISv8_IG2: true
+      CISv8_IG3: true
+      NIST800-53R5:
+      - CM-7
+  {{ end }}
   {{ end }}
 {{ end }}

--- a/section_3/cis_3.1/cis_3.1.1.yml
+++ b/section_3/cis_3.1/cis_3.1.1.yml
@@ -20,10 +20,6 @@ command:
       workstation: 1
       CIS_ID:
       - 3.1.1
-      CISv8: 4.8
-      CISv8_IG1: false
-      CISv8_IG2: true
-      CISv8_IG3: true
       NIST800-53R5:
       - CM-7
   {{ end }}
@@ -44,10 +40,6 @@ command:
       workstation: 1
       CIS_ID:
       - 3.1.1
-      CISv8: 4.8
-      CISv8_IG1: false
-      CISv8_IG2: true
-      CISv8_IG3: true
       NIST800-53R5:
       - CM-7
     {{ end }}
@@ -64,10 +56,6 @@ command:
       workstation: 1
       CIS_ID:
       - 3.1.1
-      CISv8: 4.8
-      CISv8_IG1: false
-      CISv8_IG2: true
-      CISv8_IG3: true
       NIST800-53R5:
       - CM-7
   {{ end }}
@@ -82,10 +70,6 @@ kernel-param:
       workstation: 1
       CIS_ID:
       - 3.1.1
-      CISv8: 4.8
-      CISv8_IG1: false
-      CISv8_IG2: true
-      CISv8_IG3: true
       NIST800-53R5:
       - CM-7
   {{ end }}

--- a/vars/CIS.yml
+++ b/vars/CIS.yml
@@ -543,6 +543,9 @@ rhel10cis_bluetooth_mask: false
 ## IPv6 required
 rhel10cis_ipv6_required: true
 
+# rhel10cis_ipv6_disable defines the method of disabling IPv6, sysctl vs kernel
+rhel10cis_ipv6_disable_method: sysctl
+
 ## 3.2 System network parameters (host only OR host and router)
 rhel10cis_is_router: false
 


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Update 3.1.1 audit logic via var rhel10cis_ipv6_disable_method

**How has this been tested?:**
GH Pipeline

