### PR TITLE
2026 FEB QA Updates to align with Private

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,11 +2,31 @@
 
 ## CIS 1.0.1
 
+2026 FEB QA UPDATES
+
+- removed 5.3.2.x from vars/main
+- updated BENCHMARK_VER to 1.0.1 in run_audit.sh
+- updated LICENSE copyright year to 2026
+- standalone.yml: fixed section_1/cis_1.8 path to cis_1.8.x
+- standalone.yml: fixed section_3/cis_3.3 path to cis_3.3.1 and cis_3.3.2
+- standalone.yml: added missing section_6 paths (6.2.1.x, 6.2.2.1.x)
+- standalone.yml: fixed section_6/cis_6.2.4 path to cis_6.2.4.x
+- README.md: fixed "clone" to "cloned", "RHEL 9" to "RHEL 10", heading capitalization
+- vars/CIS.yml: fixed typos (",a llow" and "seperated")
+- Changelog.md: fixed typos (udpated, npt, seperate)
+- 1.1.2.5.1: fixed NIST800-53R4 to NIST800-53R5
+- 1.4.2: fixed missing space in title pipe separator
+- 1.5.4: fixed swapped live/conf test descriptions
+- 3.3.1.4: fixed missing space in title pipe separator
+- 5.1.2: fixed malformed _group/_user title suffixes to pipe-separated format
+- 5.1.3: fixed malformed _group/_user title suffixes and variable typo (keysperm to keyperms)
+- 5.2.1: fixed template variable spacing and indentation
+
 - 3.1.1
   - Added option to audit disable IPv6 via sysctl (original method) or via the kernel
 - updated version
 - 1.4.2 removed efi steps
-- 2.1.4 udpated for kea services
+- 2.1.4 updated for kea services
 - 6.3.3.8 updated
 - 6.3.3.34 updated
 
@@ -58,8 +78,8 @@ aligned with remediate
   - logrotate - 4.3.x
 
 - aligned with rh8 v2.0
-- removed iptables (npt valid on rhel9)
-- logrotate extended as seperate package
+- removed iptables (not valid on rhel9)
+- logrotate extended as separate package
 - 1.6.1.4 - selinux disabled via config file no longer valid checked via boot in 1.6.1.2
 
 ## Initial

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
+Copyright (c) 2026 Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You must have [goss](https://github.com/goss-org/goss/) available to your host y
 
 You must have sudo/root access to the system as some commands require privilege information.
 
-Assuming you have already clone this repository you can run goss from where you wish.
+Assuming you have already cloned this repository you can run goss from where you wish.
 
 Please refer to the audit documentation for usage.
 
@@ -49,13 +49,13 @@ Which will:
 
 On our [Discord Server](https://www.lockdownenterprise.com/discord) to ask questions, discuss features, or just chat with other Ansible-Lockdown users
 
-Set of configuration files and directories to run the first stages of CIS of RHEL 9 servers
+Set of configuration files and directories to run the first stages of CIS of RHEL 10 servers
 
 This is configured in a directory structure level.
 
 Goss is run based on the goss.yml file in the top level directory. This specifies the configuration.
 
-## further information
+## Further Information
 
 - [goss documentation](https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#patterns)
 - [CIS standards](https://www.cisecurity.org)

--- a/run_audit.sh
+++ b/run_audit.sh
@@ -26,7 +26,7 @@
 
 # Goss benchmark variables (these should not need changing unless new release)
 BENCHMARK=CIS # Benchmark Name aligns to the audit
-BENCHMARK_VER=1.0.0
+BENCHMARK_VER=1.0.1 # Benchmark version aligns to the audit
 BENCHMARK_OS=RHEL10
 
 # Goss host Variables

--- a/section_1/cis_1.1.2.x/cis_1.1.2.5.1.yml
+++ b/section_1/cis_1.1.2.x/cis_1.1.2.5.1.yml
@@ -12,7 +12,7 @@ mount:
       workstation: 2
       CIS_ID:
       - 1.1.2.5.1
-      NIST800-53R4: CM-7
+      NIST800-53R5: CM-7
       CCI: NA
   {{ end }}
 {{ end }}

--- a/section_1/cis_1.4.x/cis_1.4.2.yml
+++ b/section_1/cis_1.4.x/cis_1.4.2.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.rhel10cis_rule_1_4_2 }}
 file:
   grub_bootloaders_perms:
-    title: 1.4.2 | Ensure access to bootloader config is configured| file_perms | grub.cfg
+    title: 1.4.2 | Ensure access to bootloader config is configured | file_perms | grub.cfg
     path: /boot/grub2/grub.cfg
     exists: true
     owner: root

--- a/section_1/cis_1.5.x/cis_1.5.4.yml
+++ b/section_1/cis_1.5.x/cis_1.5.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.rhel10cis_rule_1_5_4 }}
 command:
   sysctl_suid_dumpable_live:
-    title: 1.5.4 | Ensure fs.suid_dumpable is configured | conf
+    title: 1.5.4 | Ensure fs.suid_dumpable is configured | running
     exec: sysctl fs.suid_dumpable
     exit-status:
       or:
@@ -24,7 +24,7 @@ command:
       - 002165
       - 002235
   sysctl_suid_dumpable_conf:
-    title: 1.5.4 | Ensure fs.suid_dumpable is configured | running
+    title: 1.5.4 | Ensure fs.suid_dumpable is configured | conf
     exec: grep -R fs.suid_dumpable /etc/sysctl.conf /etc/sysctl.d/
     exit-status:
       or:

--- a/section_3/cis_3.3.1/cis_3.3.1.4.yml
+++ b/section_3/cis_3.3.1/cis_3.3.1.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.rhel10cis_rule_3_3_1_4 }}
 kernel-param:
   net.ipv4.conf.all.send_redirects:
-    title: 3.3.1.4 | Ensure net.ipv4.conf.all.send_redirects is configured| live
+    title: 3.3.1.4 | Ensure net.ipv4.conf.all.send_redirects is configured | live
     value: '0'
     name: net.ipv4.conf.all.send_redirects
     meta:

--- a/section_5/cis_5.1/cis_5.1.2.yml
+++ b/section_5/cis_5.1/cis_5.1.2.yml
@@ -17,7 +17,7 @@ command:
       - AC-3
       - MP-2
   /etc/ssh/ssh_host_prv_key_group:
-    title: 5.1.2 | Ensure permissions on SSH private host key files are configured_group
+    title: 5.1.2 | Ensure permissions on SSH private host key files are configured | group
     exec: "groupkeys=$(sudo find /etc/ssh/ -name *_key -type f ! -group root ); echo $groupkeys"
     exit-status: 0
     stdout: ['!/./']
@@ -30,7 +30,7 @@ command:
       - AC-3
       - MP-2
   /etc/ssh/ssh_host_prv_key_perms:
-    title: 5.1.2 | Ensure permissions on SSH private host key files are configured_user
+    title: 5.1.2 | Ensure permissions on SSH private host key files are configured | permissions
     exec: "keyperms=$(sudo find /etc/ssh/ -name *_key -type f -perm /137 ); echo $keyperms"
     exit-status: 0
     stdout: ['!/./']

--- a/section_5/cis_5.1/cis_5.1.3.yml
+++ b/section_5/cis_5.1/cis_5.1.3.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.rhel10cis_rule_5_1_3 }}
 command:
   /etc/ssh/ssh_host_pub_key_user:
-    title: 5.1.3 | Ensure permissions on SSH pub host key files are configured_user
+    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | user
     exec: "userkeys=$(sudo find /etc/ssh/ -name *_key -type f ! -user root ! -group root ); echo $userkeys"
     exit-status: 0
     stdout: ['!/./']
@@ -17,7 +17,7 @@ command:
       - AC-3
       - MP-2
   /etc/ssh/ssh_host_pub_key_group:
-    title: 5.1.3 | Ensure permissions on SSH public host key files are configured_group
+    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | group
     exec: "groupkeys=$(sudo find /etc/ssh/ -name *_key.pub -type f ! -group root ); echo $groupkeys"
     exit-status: 0
     stdout: ['!/./']
@@ -30,8 +30,8 @@ command:
       - AC-3
       - MP-2
   /etc/ssh/ssh_host_pub_key_perms:
-    title: 5.1.3 | Ensure permissions on SSH public host key files are configured_user
-    exec: "keysperm=$(sudo find /etc/ssh/ -name *_key.pub -type f -perm /133 ); echo $keyperms"
+    title: 5.1.3 | Ensure permissions on SSH public host key files are configured | permissions
+    exec: "keyperms=$(sudo find /etc/ssh/ -name *_key.pub -type f -perm /133 ); echo $keyperms"
     exit-status: 0
     stdout: ['!/./']
     meta:

--- a/section_5/cis_5.2/cis_5.2.1.yml
+++ b/section_5/cis_5.2/cis_5.2.1.yml
@@ -1,9 +1,9 @@
 ---
 
 {{ if .Vars.rhel10cis_level_1 }}
-  {{ if .Vars.rhel10cis_rule_5_2_1}}
+  {{ if .Vars.rhel10cis_rule_5_2_1 }}
 package:
- sudo:
+  sudo:
     title: 5.2.1 | Ensure sudo is installed
     installed: true
     meta:

--- a/standalone.yml
+++ b/standalone.yml
@@ -8,7 +8,7 @@ gossfile:
   section_1/cis_1.5.x/*.yml: {}
   section_1/cis_1.6.x/*.yml: {}
   section_1/cis_1.7.x/*.yml: {}
-  section_1/cis_1.8/*.yml: {}
+  section_1/cis_1.8.x/*.yml: {}
   {{ end }}
   {{ if .Vars.rhel10cis_section2 }}
   section_2/*/*.yml: {}
@@ -16,7 +16,8 @@ gossfile:
   {{ if .Vars.rhel10cis_section3 }}
   section_3/cis_3.1/*.yml: {}
   section_3/cis_3.2/*.yml: {}
-  section_3/cis_3.3/*.yml: {}
+  section_3/cis_3.3.1/*.yml: {}
+  section_3/cis_3.3.2/*.yml: {}
 ## firewall configurations
   {{ end }}
   {{ if .Vars.rhel10cis_section4 }}
@@ -29,13 +30,15 @@ gossfile:
   {{ end }}
   {{ if .Vars.rhel10cis_section6 }}
   section_6/cis_6.1/*.yml: {}
+  section_6/cis_6.2.1.x/*.yml: {}
+  section_6/cis_6.2.2.1.x/*.yml: {}
     {{ if eq .Vars.rhel10cis_syslog "journald" }}
   section_6/cis_6.2.2.x/*.yml: {}
     {{ end }}
     {{ if eq .Vars.rhel10cis_syslog "rsyslog" }}
   section_6/cis_6.2.3.x/*.yml: {}
     {{ end }}
-  section_6/cis_6.2.4/*.yml: {}
+  section_6/cis_6.2.4.x/*.yml: {}
     # Auditd and level 2
     {{ if .Vars.rhel10cis_level_2 }}
   section_6/cis_6.3.*/*.yml: {}

--- a/vars/CIS.yml
+++ b/vars/CIS.yml
@@ -281,12 +281,6 @@ rhel10cis_rule_5_3_1_2: true
 rhel10cis_rule_5_3_1_3: true
 rhel10cis_rule_5_3_1_4: true
 rhel10cis_rule_5_3_1_5: true
-# 5.3.2 Configure authselect
-rhel10cis_rule_5_3_2_1: true
-rhel10cis_rule_5_3_2_2: true
-rhel10cis_rule_5_3_2_3: true
-rhel10cis_rule_5_3_2_4: true
-rhel10cis_rule_5_3_2_5: true
 # 5.3.2.1 Configure pam_faillock module
 rhel10cis_rule_5_3_2_1_1: true
 rhel10cis_rule_5_3_2_1_2: true
@@ -557,7 +551,7 @@ rhel10cis_firewall: firewalld
 # Name of the new firewall zone that should be live
 rhel10cis_active_firewall_zone: public
 # If set to accept change to one of DROP or DEFAULT
-# DEFAULT - Deny by default,a llow by exception including ICMP
+# DEFAULT - Deny by default, allow by exception including ICMP
 # DROP - Will drop all attempts to connect that are not whitelisted
 rhel10cis_firewalld_target: DROP
 
@@ -565,7 +559,7 @@ rhel10cis_firewalld_target: DROP
 
 rhel10_cis_sshd_config_file: /etc/ssh/sshd_config
 
-## 5.1.7 Note the following to understand precedence and layout , comma seperated
+## 5.1.7 Note the following to understand precedence and layout, comma separated
 rhel10cis_sshd_allowusers: vagrant
 rhel10cis_sshd_allowgroups:
 rhel10cis_sshd_denyusers: nobody


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
2026 FEB QA UPDATES

- removed 5.3.2.x from vars/main
- updated BENCHMARK_VER to 1.0.1 in run_audit.sh
- updated LICENSE copyright year to 2026
- standalone.yml: fixed section_1/cis_1.8 path to cis_1.8.x
- standalone.yml: fixed section_3/cis_3.3 path to cis_3.3.1 and cis_3.3.2
- standalone.yml: added missing section_6 paths (6.2.1.x, 6.2.2.1.x)
- standalone.yml: fixed section_6/cis_6.2.4 path to cis_6.2.4.x
- README.md: fixed "clone" to "cloned", "RHEL 9" to "RHEL 10", heading capitalization
- vars/CIS.yml: fixed typos (",a llow" and "seperated")
- Changelog.md: fixed typos (udpated, npt, seperate)
- 1.1.2.5.1: fixed NIST800-53R4 to NIST800-53R5
- 1.4.2: fixed missing space in title pipe separator
- 1.5.4: fixed swapped live/conf test descriptions
- 3.3.1.4: fixed missing space in title pipe separator
- 5.1.2: fixed malformed _group/_user title suffixes to pipe-separated format
- 5.1.3: fixed malformed _group/_user title suffixes and variable typo (keysperm to keyperms)
- 5.2.1: fixed template variable spacing and indentation

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A
GH Pipeline
